### PR TITLE
provide an --identifier option to jpackage

### DIFF
--- a/doc/user_guide.adoc
+++ b/doc/user_guide.adoc
@@ -153,6 +153,10 @@ installerName:: the argument passed to the `--name` option when running `jpackag
 jvmArgs:: list of JVM arguments to be passed to the virtual machine. +
     _defaultValue_: the `jvmArgs` value configured in the `launcher` block or an empty list
 
+identifier:: the argument passed to the `--identifier` option when running `jpackage` when executing the `jpackage` task. +
+    _defaultValue_: the main class name +
+    _usage example_: `identifier = "org.example.MyApp"`
+
 installerOptions:: list of additional options to be passed to the `jpackage` executable when creating the application installer. +
     _defaultValue_: empty list +
     _usage example_: `installerOptions = ["--win-console"]`

--- a/src/main/groovy/org/beryx/runtime/data/JPackageData.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/JPackageData.groovy
@@ -55,6 +55,9 @@ class JPackageData {
 
     String installerName
 
+    @Input @Optional
+    String identifier
+
     @Input
     List<String> installerOptions = []
 

--- a/src/main/groovy/org/beryx/runtime/impl/JPackageImageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/JPackageImageTaskImpl.groovy
@@ -56,6 +56,7 @@ class JPackageImageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                            '--main-class', jpd.mainClass,
                            '--output', outputDir,
                            '--name', jpd.imageName,
+                           '--identifier', jpd.identifier ?: jpd.mainClass,
                            '--runtime-image', td.runtimeImageDir,
                            *(jpd.jvmArgs ? jpd.jvmArgs.collect{['--java-options', adjustArg(it)]}.flatten() : []),
                            *jpd.imageOptions]


### PR DESCRIPTION
This is based on a similar change to the Badass JLink Plugin:
https://github.com/beryx/badass-jlink-plugin/commit/c2190c5772be3cdc59230945aadadd0549cefe9c

The only difference is the fallback when identifier is not available
is jpd.mainClass rather than td.mainClass (which doesn’t exist in the
Runtime plugin)