### PR TITLE
feat: provide an --resource-dir option to jpackage

### DIFF
--- a/doc/user_guide.adoc
+++ b/doc/user_guide.adoc
@@ -134,6 +134,10 @@ imageOptions:: list of additional options to be passed to the `jpackage` executa
     _defaultValue_: empty list +
     _usage example_: `imageOptions = ["--win-console"]`
 
+resourceDir:: the directory passed as argument to the `--resource-dir` option when running `jpackage` to create an application installer.
+It is also applicable when creating an application image when you want your own application image instead of the default java image. +
+    _usage example_: `resourceDir = file("$buildDir/my-packaging-resources")`
+
 skipInstaller:: boolean value that lets you generate only the platform-specific application image and skip the generation of the platform-specific application installer. +
     _defaultValue_: false +
     _usage example_: `skipInstaller = true`

--- a/src/main/groovy/org/beryx/runtime/data/JPackageData.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/JPackageData.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
 import static org.beryx.runtime.util.Util.EXEC_EXTENSION
 
@@ -41,6 +42,9 @@ class JPackageData {
 
     @Input
     List<String> imageOptions = []
+
+    @Input @Optional
+    File resourceDir
 
     @Input @Optional
     String targetPlatformName
@@ -87,6 +91,11 @@ class JPackageData {
     @Input
     String getInstallerName() {
         this.@installerName ?: project.name
+    }
+
+    @InputDirectory
+    File getResourceDir() {
+        this.@resourceDir ?: project.buildDir
     }
 
     @OutputDirectory

--- a/src/main/groovy/org/beryx/runtime/impl/JPackageImageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/JPackageImageTaskImpl.groovy
@@ -58,6 +58,7 @@ class JPackageImageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                            '--name', jpd.imageName,
                            '--identifier', jpd.identifier ?: jpd.mainClass,
                            '--runtime-image', td.runtimeImageDir,
+                           '--resource-dir', jpd.getResourceDir(),
                            *(jpd.jvmArgs ? jpd.jvmArgs.collect{['--java-options', adjustArg(it)]}.flatten() : []),
                            *jpd.imageOptions]
         }

--- a/src/main/groovy/org/beryx/runtime/impl/JPackageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/JPackageTaskImpl.groovy
@@ -67,6 +67,7 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                                '--output', td.jpackageData.getInstallerOutputDir(),
                                '--name', jpd.installerName,
                                '--app-image', "$appImagePath",
+                               '--resource-dir', jpd.getResourceDir(),
                                *jpd.installerOptions]
             }
             if(result.exitValue != 0) {


### PR DESCRIPTION
Add an option for jpackage resource directory. It is applicable for both jpackage and jpackageImage.

It is most relevant for creating an application installer, but also applicable for jpackageImage as it can provide an application image other than the default java image.

I wanted this optional, no need to actually add this argument if it is not set. Any suggestion how to do that? It now defaults to project.buildDir if not set.