### PR TITLE
fix: Make resource directory argument truly optional

### DIFF
--- a/src/main/groovy/org/beryx/runtime/data/JPackageData.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/JPackageData.groovy
@@ -98,7 +98,7 @@ class JPackageData {
 
     @InputDirectory
     File getResourceDir() {
-        this.@resourceDir ?: project.buildDir
+        this.@resourceDir
     }
 
     @OutputDirectory

--- a/src/main/groovy/org/beryx/runtime/impl/JPackageImageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/JPackageImageTaskImpl.groovy
@@ -63,6 +63,9 @@ class JPackageImageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                 throw new GradleException("The first character of the --app-version argument should be a digit.")
             }
 
+            final def resourceDir = jpd.getResourceDir()
+            final def resourceOpts = resourceDir == null ? [] : [ '--resource-dir', resourceDir ]
+
             commandLine = [jpackageExec,
                            '--input', "$td.runtimeImageDir${File.separator}lib",
                            '--main-jar', jpd.mainJar ?: Util.getMainDistJarFile(project).name,
@@ -71,7 +74,7 @@ class JPackageImageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                            '--name', jpd.imageName,
                            *versionOpts,
                            '--runtime-image', td.runtimeImageDir,
-                           '--resource-dir', jpd.getResourceDir(),
+                           *resourceOpts,
                            *(jpd.jvmArgs ? jpd.jvmArgs.collect{['--java-options', adjustArg(it)]}.flatten() : []),
                            *jpd.imageOptions]
         }

--- a/src/main/groovy/org/beryx/runtime/impl/JPackageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/JPackageTaskImpl.groovy
@@ -78,6 +78,9 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                     throw new GradleException("The first character of the --app-version argument should be a digit.")
                 }
 
+                final def resourceDir = jpd.getResourceDir()
+                final def resourceOpts = (resourceDir == null) ? [] : [ '--resource-dir', resourceDir ]
+
                 commandLine = [jpackageExec,
                                '--package-type', packageType,
                                '--output', td.jpackageData.getInstallerOutputDir(),
@@ -85,7 +88,7 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                                '--identifier', jpd.identifier ?: jpd.mainClass,
                                *versionOpts,
                                '--app-image', "$appImagePath",
-                               '--resource-dir', jpd.getResourceDir(),
+                               *resourceOpts,
                                *jpd.installerOptions]
             }
 


### PR DESCRIPTION
This makes the resource directory argument to jpackage truly optional.
If resource directort is not applied it should not be placed as argument
to the jpackage executable.