### PR TITLE
fix input to jpackage and jpackageImage tasks

### DIFF
--- a/src/main/groovy/org/beryx/runtime/JPackageTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/JPackageTask.groovy
@@ -32,13 +32,8 @@ class JPackageTask extends BaseTask {
     private static final Logger LOGGER = Logging.getLogger(JPackageTask.class)
 
     @InputDirectory
-    Directory getJreDir() {
-        extension.jreDir.get()
-    }
-
-    @InputDirectory
-    Directory getImageDir() {
-        extension.imageDir.get()
+    Directory getAppImageDir() {
+        extension.appImageDir.get()
     }
 
     @Nested
@@ -47,18 +42,15 @@ class JPackageTask extends BaseTask {
     }
 
     JPackageTask() {
-        dependsOn(RuntimePlugin.TASK_NAME_JPACKAGE_IMAGE)
         description = 'Creates an application installer using the jpackage tool'
+        dependsOn(RuntimePlugin.TASK_NAME_JPACKAGE_IMAGE)
     }
 
     @TaskAction
     void jpackageTaskAction() {
         def taskData = new JPackageTaskData()
-        taskData.imageDir = imageDir.asFile
         taskData.jpackageData = jpackageData
-
-        def runtimeTask = (RuntimeTask) project.tasks.getByName(RuntimePlugin.TASK_NAME_RUNTIME)
-        taskData.configureRuntimeImageDir(runtimeTask)
+        taskData.configureAppImageDir()
 
         def taskImpl = new JPackageTaskImpl(project, taskData)
         taskImpl.execute()

--- a/src/main/groovy/org/beryx/runtime/JreTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/JreTask.groovy
@@ -51,8 +51,13 @@ class JreTask extends BaseTask {
         extension.jreDir.get()
     }
 
+    @OutputDirectory
+    File getJreDirAsFile() {
+        jreDir.asFile
+    }
+
     JreTask() {
-        description = 'Creates a custom JRE'
+        description = 'Creates a custom java runtime image with jlink'
     }
 
     @TaskAction

--- a/src/main/groovy/org/beryx/runtime/data/RuntimePluginExtension.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/RuntimePluginExtension.groovy
@@ -31,6 +31,7 @@ import org.gradle.api.provider.Provider
 class RuntimePluginExtension {
     final DirectoryProperty distDir
     final DirectoryProperty jreDir
+    final DirectoryProperty appImageDir
     final DirectoryProperty imageDir
     final RegularFileProperty imageZip
 
@@ -47,6 +48,9 @@ class RuntimePluginExtension {
 
         jreDir = Util.createDirectoryProperty(project)
         jreDir.set(project.layout.buildDirectory.dir('jre'))
+
+        appImageDir = Util.createDirectoryProperty(project)
+        appImageDir.set(project.layout.buildDirectory.dir('appImage'))
 
         imageDir = Util.createDirectoryProperty(project)
         imageDir.set(project.layout.buildDirectory.dir('image'))


### PR DESCRIPTION
This fixed the issue with duplicated data input and runtime image [#33].

Use distribution directory as input and jre directory as runtime image
to jpackageImage task. Then use the appImage from the jpackageImage as
input to jpackage task for creating application installers.