### PR TITLE
fix: Remove the appImageDir input from JPackageTask

### DIFF
--- a/src/main/groovy/org/beryx/runtime/JPackageTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/JPackageTask.groovy
@@ -15,26 +15,19 @@
  */
 package org.beryx.runtime
 
-import groovy.transform.CompileStatic
 import org.beryx.runtime.data.JPackageData
 import org.beryx.runtime.data.JPackageTaskData
 import org.beryx.runtime.impl.JPackageTaskImpl
-import org.gradle.api.file.Directory
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
+
+import groovy.transform.CompileStatic
 
 @CompileStatic
 class JPackageTask extends BaseTask {
     private static final Logger LOGGER = Logging.getLogger(JPackageTask.class)
-
-    @InputDirectory
-    Directory getAppImageDir() {
-        extension.appImageDir.get()
-    }
 
     @Nested
     JPackageData getJpackageData() {

--- a/src/main/groovy/org/beryx/runtime/data/RuntimePluginExtension.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/RuntimePluginExtension.groovy
@@ -15,8 +15,6 @@
  */
 package org.beryx.runtime.data
 
-import groovy.transform.CompileStatic
-import groovy.transform.ToString
 import org.beryx.runtime.util.Util
 import org.gradle.api.Action
 import org.gradle.api.Project
@@ -26,12 +24,14 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 
+import groovy.transform.CompileStatic
+import groovy.transform.ToString
+
 @CompileStatic
 @ToString(includeNames = true)
 class RuntimePluginExtension {
     final DirectoryProperty distDir
     final DirectoryProperty jreDir
-    final DirectoryProperty appImageDir
     final DirectoryProperty imageDir
     final RegularFileProperty imageZip
 
@@ -48,9 +48,6 @@ class RuntimePluginExtension {
 
         jreDir = Util.createDirectoryProperty(project)
         jreDir.set(project.layout.buildDirectory.dir('jre'))
-
-        appImageDir = Util.createDirectoryProperty(project)
-        appImageDir.set(project.layout.buildDirectory.dir('appImage'))
 
         imageDir = Util.createDirectoryProperty(project)
         imageDir.set(project.layout.buildDirectory.dir('image'))


### PR DESCRIPTION
A small regression in my previous feature change which caused jpackage task to fail.

```
A problem was found with the configuration of task 'jpackage'.
> Directory '/home/sverre/workspace/javafx-test/build/appImage' specified for property 'appImageDir' does not exist.
```

The appImageDir input to JPackageTask was a mistake. It does not need an input parameter, since its appImageDir is combined by the outputDir and imageName.