### PR TITLE
jre task should depend on any jars in the runtime classpath

### DIFF
--- a/src/main/groovy/org/beryx/runtime/JreTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/JreTask.groovy
@@ -63,6 +63,7 @@ class JreTask extends BaseTask {
 
     JreTask() {
         dependsOn('jar')
+        dependsOn(project.configurations.runtimeClasspath.allDependencies)
         description = 'Creates a custom java runtime image with jlink'
     }
 


### PR DESCRIPTION
Fixes #130.

`allDependencies` returns a lazy collection which includes all the runtime dependencies. Those which come from projects will be a `ProjectDependency` along the lines of:

```
DefaultProjectDependency{dependencyProject='project ':lib'', configuration='default'}
```

This seems to make it run `:lib:jar` as part of the dependencies for the task.