### PR TITLE
Removes usage of mainClassName if running Gradle 7 or later.

### DIFF
--- a/src/main/groovy/org/beryx/runtime/RuntimeTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/RuntimeTask.groovy
@@ -98,7 +98,7 @@ class RuntimeTask extends BaseTask {
             }
             // workaround for shadow bug https://github.com/johnrengelman/shadow/issues/572
             if(GradleVersion.current() >= GradleVersion.version('6.4')) {
-                if(!startScriptTask.mainClass.present) {
+                if(!startScriptTask.mainClass.present && GradleVersion.current() < GradleVersion.version('7.0')) {
                     startScriptTask.mainClass.set(startScriptTask.mainClassName)
                 }
             }


### PR DESCRIPTION
mainClassName it is now deprecated so using it results in warnings in the build output.

Fixes #115.