### PR TITLE
Make `TargetPlatform` a managed type

### DIFF
--- a/src/main/groovy/org/beryx/runtime/JreTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/JreTask.groovy
@@ -19,9 +19,10 @@ import groovy.transform.CompileStatic
 import org.beryx.runtime.data.JreTaskData
 import org.beryx.runtime.data.TargetPlatform
 import org.beryx.runtime.impl.JreTaskImpl
-import org.gradle.api.GradleException
 import org.gradle.api.file.Directory
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
@@ -47,9 +48,9 @@ class JreTask extends BaseTask {
         javaHomeOrDefault
     }
 
-    @Input
-    Map<String, TargetPlatform> getTargetPlatforms() {
-        extension.targetPlatforms.collectEntries()
+    @Nested
+    MapProperty<String, TargetPlatform> getTargetPlatforms() {
+        extension.targetPlatforms
     }
 
     @OutputDirectory
@@ -76,7 +77,7 @@ class JreTask extends BaseTask {
         taskData.additive = additive
         taskData.modules = modules
         taskData.javaHome = javaHome
-        taskData.targetPlatforms = targetPlatforms
+        taskData.targetPlatforms = targetPlatforms.get()
 
         def taskImpl = new JreTaskImpl(project, taskData)
         taskImpl.execute()

--- a/src/main/groovy/org/beryx/runtime/JreTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/JreTask.groovy
@@ -49,7 +49,7 @@ class JreTask extends BaseTask {
 
     @Input
     Map<String, TargetPlatform> getTargetPlatforms() {
-        extension.targetPlatforms.get()
+        extension.targetPlatforms.collectEntries()
     }
 
     @OutputDirectory

--- a/src/main/groovy/org/beryx/runtime/RuntimeTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/RuntimeTask.groovy
@@ -34,7 +34,7 @@ import org.gradle.jvm.application.scripts.TemplateBasedScriptGenerator
 class RuntimeTask extends BaseTask {
     @Input
     Map<String, TargetPlatform> getTargetPlatforms() {
-        extension.targetPlatforms.get()
+        extension.targetPlatforms.collectEntries()
     }
 
     @Nested

--- a/src/main/groovy/org/beryx/runtime/RuntimeTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/RuntimeTask.groovy
@@ -25,6 +25,7 @@ import org.beryx.runtime.impl.RuntimeTaskImpl
 import org.beryx.runtime.util.Util
 import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.file.Directory
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.application.CreateStartScripts
 import org.gradle.jvm.application.scripts.ScriptGenerator
@@ -32,9 +33,9 @@ import org.gradle.jvm.application.scripts.TemplateBasedScriptGenerator
 
 @CompileStatic
 class RuntimeTask extends BaseTask {
-    @Input
-    Map<String, TargetPlatform> getTargetPlatforms() {
-        extension.targetPlatforms.collectEntries()
+    @Nested
+    MapProperty<String, TargetPlatform> getTargetPlatforms() {
+        extension.targetPlatforms
     }
 
     @Nested
@@ -132,7 +133,7 @@ class RuntimeTask extends BaseTask {
         taskData.distDir = distDir.asFile
         taskData.jreDir = jreDir.asFile
         taskData.imageDir = imageDir.asFile
-        taskData.targetPlatforms = targetPlatforms
+        taskData.targetPlatforms = targetPlatforms.get()
 
         def taskImpl = new RuntimeTaskImpl(project, taskData)
         taskImpl.execute()

--- a/src/main/groovy/org/beryx/runtime/RuntimeZipTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/RuntimeZipTask.groovy
@@ -30,7 +30,7 @@ import org.gradle.api.tasks.TaskAction
 class RuntimeZipTask extends BaseTask {
     @Input
     Map<String, TargetPlatform> getTargetPlatforms() {
-        extension.targetPlatforms.get()
+        extension.targetPlatforms.collectEntries()
     }
 
     @InputDirectory

--- a/src/main/groovy/org/beryx/runtime/RuntimeZipTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/RuntimeZipTask.groovy
@@ -21,16 +21,17 @@ import org.beryx.runtime.data.TargetPlatform
 import org.beryx.runtime.impl.RuntimeZipTaskImpl
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
-import org.gradle.api.tasks.Input
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 @CompileStatic
 class RuntimeZipTask extends BaseTask {
-    @Input
-    Map<String, TargetPlatform> getTargetPlatforms() {
-        extension.targetPlatforms.collectEntries()
+    @Nested
+    MapProperty<String, TargetPlatform> getTargetPlatforms() {
+        extension.targetPlatforms
     }
 
     @InputDirectory
@@ -51,7 +52,7 @@ class RuntimeZipTask extends BaseTask {
     @TaskAction
     void runtimeZipTaskAction() {
         def taskData = new RuntimeZipTaskData()
-        taskData.targetPlatforms = targetPlatforms
+        taskData.targetPlatforms = targetPlatforms.get()
         taskData.imageDir = imageDir.asFile
         taskData.imageZip = imageZip.asFile
         def taskImpl = new RuntimeZipTaskImpl(project, taskData)

--- a/src/main/groovy/org/beryx/runtime/data/JPackageTaskData.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/JPackageTaskData.groovy
@@ -54,7 +54,7 @@ class JPackageTaskData {
     }
 
     void configureRuntimeImageDir(JreTask jreTask) {
-        def jlinkPlatforms = jreTask.targetPlatforms
+        def jlinkPlatforms = jreTask.targetPlatforms.get()
         if (jpackageData.targetPlatformName) {
             if (!jlinkPlatforms.isEmpty()) {
                 if (!jlinkPlatforms.keySet().contains(jpackageData.targetPlatformName)) {

--- a/src/main/groovy/org/beryx/runtime/data/RuntimePluginExtension.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/RuntimePluginExtension.groovy
@@ -40,7 +40,7 @@ class RuntimePluginExtension {
     final Property<Boolean> additive
     final ListProperty<String> modules
     final Property<String> javaHome
-    final NamedDomainObjectContainer targetPlatforms
+    final NamedDomainObjectContainer<TargetPlatform> targetPlatforms
     final Property<Integer> jvmVersion
 
     final Property<LauncherData> launcherData

--- a/src/main/groovy/org/beryx/runtime/data/RuntimePluginExtension.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/RuntimePluginExtension.groovy
@@ -17,13 +17,12 @@ package org.beryx.runtime.data
 
 import org.beryx.runtime.util.Util
 import org.gradle.api.Action
-import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 
 import groovy.transform.CompileStatic
 
@@ -40,7 +39,7 @@ class RuntimePluginExtension {
     final Property<Boolean> additive
     final ListProperty<String> modules
     final Property<String> javaHome
-    final NamedDomainObjectContainer<TargetPlatform> targetPlatforms
+    final MapProperty<String, TargetPlatform> targetPlatforms
     final Property<Integer> jvmVersion
 
     final Property<LauncherData> launcherData
@@ -71,7 +70,7 @@ class RuntimePluginExtension {
 
         javaHome = project.objects.property(String)
 
-        targetPlatforms = project.objects.domainObjectContainer(TargetPlatform)
+        targetPlatforms = project.objects.mapProperty(String, TargetPlatform)
 
         jvmVersion = project.objects.property(Integer)
 
@@ -103,10 +102,9 @@ class RuntimePluginExtension {
     }
 
     void targetPlatform(String name, Action<TargetPlatform> action) {
-        targetPlatforms.create(name) { TargetPlatform platform ->
-            platform.setProject(project)
-            action.execute(platform)
-        }
+        def targetPlatform = new TargetPlatform(project, name)
+        targetPlatforms.put(name, targetPlatform)
+        action.execute(targetPlatform)
     }
 
     void enableCds(Action<CdsData> action = null) {

--- a/src/main/groovy/org/beryx/runtime/data/TargetPlatform.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/TargetPlatform.groovy
@@ -16,60 +16,42 @@
 package org.beryx.runtime.data
 
 
-import groovy.transform.CompileStatic
 import org.beryx.runtime.util.JdkUtil
+import org.gradle.api.Named
 import org.gradle.api.Project
+import org.gradle.api.internal.provider.DefaultProvider
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 
-@CompileStatic
-class TargetPlatform implements Serializable {
+abstract class TargetPlatform implements Serializable, Named {
     private static final Logger LOGGER = Logging.getLogger(TargetPlatform.class)
+    private Project project
 
-    transient private final Project project
-    final String name
-    private Serializable jdkHome
-    List<String> options = []
+    abstract Property<String> getJdkHome()
+    abstract ListProperty<String> getOptions()
 
-    TargetPlatform(Project project, String name, String jdkHome = '', List<String> options = []) {
+    void setProject(Project project) {
         this.project = project
-        this.name = name
-        this.@jdkHome = jdkHome
-        this.options.addAll(options)
-    }
-    String getJdkHome() {
-        (this.@jdkHome == null) ? null : this.@jdkHome.toString()
     }
 
-    void setJdkHome(Serializable jdkHome) {
-        this.@jdkHome = jdkHome
+    void setJdkHome(Provider<String> jdkHome) {
+        this.jdkHome.set(jdkHome)
     }
 
     void addOptions(String... opts) {
-        opts.each { String opt -> options.add(opt) }
+        this.options.addAll(opts)
     }
 
-    private static class LazyString implements Serializable {
-        final Closure<String> closure
-        LazyString(Closure<String> closure) {
-            this.closure = closure
-        }
-
-        @Lazy String string = closure.call()
-
-        @Override
-        String toString() {
-            string
-        }
-    }
-
-    LazyString jdkDownload(String downloadUrl, Closure downloadConfig = null) {
+    Provider<String> jdkDownload(String downloadUrl, Closure downloadConfig = null) {
         def options = new JdkUtil.JdkDownloadOptions(project, name, downloadUrl)
         if(downloadConfig) {
             downloadConfig.delegate = options
             downloadConfig(options)
         }
-        return new LazyString({
+        return new DefaultProvider<String>({
             def relativePathToHome = JdkUtil.downloadFrom(downloadUrl, options)
             def pathToHome = "$options.downloadDir/$relativePathToHome"
             LOGGER.info("Home of downloaded JDK distribution: $pathToHome")

--- a/src/main/groovy/org/beryx/runtime/data/TargetPlatform.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/TargetPlatform.groovy
@@ -15,7 +15,7 @@
  */
 package org.beryx.runtime.data
 
-
+import groovy.transform.CompileStatic
 import org.beryx.runtime.util.JdkUtil
 import org.gradle.api.Named
 import org.gradle.api.Project
@@ -26,6 +26,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 
+@CompileStatic
 abstract class TargetPlatform implements Serializable, Named {
     private static final Logger LOGGER = Logging.getLogger(TargetPlatform.class)
     private Project project

--- a/src/main/groovy/org/beryx/runtime/data/TargetPlatform.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/TargetPlatform.groovy
@@ -17,7 +17,6 @@ package org.beryx.runtime.data
 
 import groovy.transform.CompileStatic
 import org.beryx.runtime.util.JdkUtil
-import org.gradle.api.Named
 import org.gradle.api.Project
 import org.gradle.api.internal.provider.DefaultProvider
 import org.gradle.api.logging.Logger
@@ -25,17 +24,25 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
 
 @CompileStatic
-abstract class TargetPlatform implements Serializable, Named {
-    private static final Logger LOGGER = Logging.getLogger(TargetPlatform.class)
-    private Project project
+class TargetPlatform {
+    static final Logger LOGGER = Logging.getLogger(TargetPlatform.class)
 
-    abstract Property<String> getJdkHome()
-    abstract ListProperty<String> getOptions()
+    private final Project project
+    @Input
+    final String name
+    @Input
+    final Property<String> jdkHome
+    @Input
+    final ListProperty<String> options
 
-    void setProject(Project project) {
+    TargetPlatform(Project project, String name) {
+        this.name = name
         this.project = project
+        jdkHome = project.objects.property(String)
+        options = project.objects.listProperty(String)
     }
 
     void setJdkHome(Provider<String> jdkHome) {

--- a/src/main/groovy/org/beryx/runtime/impl/JreTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/JreTaskImpl.groovy
@@ -36,7 +36,7 @@ class JreTaskImpl extends BaseTaskImpl<JreTaskData> {
         if(td.targetPlatforms) {
             td.targetPlatforms.values().each { platform ->
                 File jreDir = new File(td.jreDir, "$project.name-$platform.name")
-                createJre(jreDir, platform.jdkHome, td.options + platform.options)
+                createJre(jreDir, platform.jdkHome.getOrNull(), td.options + platform.options.get())
             }
         } else {
             createJre(td.jreDir, td.javaHome, td.options)


### PR DESCRIPTION
This PR converts `TargetPlatform` to use [managed properties](https://docs.gradle.org/current/userguide/custom_gradle_types.html#managed_properties).

In short, this means that `TargetPlatform` is not instantiated directly in the codebase, but by Gradle (which fill in the various properties for us)

In addition, I changed the holding type for `RuntimePluginExtension.targetPlatforms` to [NamedDomainObjectContainer](https://docs.gradle.org/7.6/javadoc/org/gradle/api/NamedDomainObjectContainer.html) which is basically the default "map like" container for gradle plugins.