### PR TITLE
Use `BaseTask` java home in jpackage tasks

### DIFF
--- a/src/main/groovy/org/beryx/runtime/JPackageImageTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/JPackageImageTask.groovy
@@ -67,6 +67,7 @@ class JPackageImageTask extends BaseTask {
         def taskData = new JPackageTaskData()
         taskData.distDir = distDir.asFile
         taskData.jpackageData = jpackageData
+        taskData.javaHome = javaHomeOrDefault
 
         def jreTask = (JreTask) project.tasks.getByName(RuntimePlugin.TASK_NAME_JRE)
         taskData.configureRuntimeImageDir(jreTask)

--- a/src/main/groovy/org/beryx/runtime/JPackageTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/JPackageTask.groovy
@@ -43,6 +43,7 @@ class JPackageTask extends BaseTask {
     void jpackageTaskAction() {
         def taskData = new JPackageTaskData()
         taskData.jpackageData = jpackageData
+        taskData.javaHome = javaHomeOrDefault
         taskData.configureAppImageDir()
 
         def taskImpl = new JPackageTaskImpl(project, taskData)

--- a/src/main/groovy/org/beryx/runtime/data/JPackageData.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/JPackageData.groovy
@@ -127,11 +127,6 @@ class JPackageData {
     }
 
     @Internal
-    String getJPackageHomeOrDefault() {
-        return jpackageHome ?: defaultJPackageHome
-    }
-
-    @Internal
     String getDefaultJPackageHome() {
         def value = System.properties['badass.runtime.jpackage.home']
         if(value) return value

--- a/src/main/groovy/org/beryx/runtime/data/JPackageData.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/JPackageData.groovy
@@ -125,17 +125,4 @@ class JPackageData {
     File getInstallerOutputDirOrDefault() {
         this.@installerOutputDir ?: project.file("$project.buildDir/$outputDir")
     }
-
-    @Internal
-    String getDefaultJPackageHome() {
-        def value = System.properties['badass.runtime.jpackage.home']
-        if(value) return value
-        value = System.getenv('BADASS_RUNTIME_JPACKAGE_HOME')
-        if(value) return value
-        value = Util.getDefaultToolchainJavaHome(project)
-        if(value) return value
-        value = System.properties['java.home']
-        if(new File("$value/bin/jpackage$EXEC_EXTENSION").file) return value
-        return System.getenv('JAVA_HOME')
-    }
 }

--- a/src/main/groovy/org/beryx/runtime/data/JPackageTaskData.groovy
+++ b/src/main/groovy/org/beryx/runtime/data/JPackageTaskData.groovy
@@ -35,6 +35,7 @@ class JPackageTaskData {
     File appImageDir
 
     JPackageData jpackageData
+    String javaHome
 
     void configureAppImageDir() {
         final def imgOutDir = jpackageData.imageOutputDirOrDefault

--- a/src/main/groovy/org/beryx/runtime/impl/JPackageImageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/JPackageImageTaskImpl.groovy
@@ -50,7 +50,7 @@ class JPackageImageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
             def outputDir = jpd.imageOutputDirOrDefault
             project.delete(outputDir)
 
-            def jpackageExec = "${jpd.getJPackageHomeOrDefault()}/bin/jpackage$EXEC_EXTENSION"
+            def jpackageExec = "${td.javaHome}/bin/jpackage$EXEC_EXTENSION"
             Util.checkExecutable(jpackageExec)
 
             def inputSuffix = project.tasks.findByName('installShadowDist') ? '-shadow' : ''

--- a/src/main/groovy/org/beryx/runtime/impl/JPackageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/JPackageTaskImpl.groovy
@@ -62,7 +62,7 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                 project.ext.jpackageInstallerOutput = {
                     return standardOutput.toString()
                 }
-                def jpackageExec = "${jpd.getJPackageHomeOrDefault()}/bin/jpackage$EXEC_EXTENSION"
+                def jpackageExec = "${td.javaHome}/bin/jpackage$EXEC_EXTENSION"
                 Util.checkExecutable(jpackageExec)
 
                 def appVersion = (jpd.appVersion ?: project.version).toString()


### PR DESCRIPTION
This PR removes the java home in `JPackageData` and uses instead the one defined in `BaseTask`. 

This is to fix an issue where specifying a different java home in the configuration doesn't apply to the jpackage task.

I tested it by using [this branch](https://github.com/fourlastor-alexandria/construo-gdx/pull/1) and running the task `test:packageWinX64` on Windows (which will run the jpackage task)

This requires to have a setup like the following:

```
/construo-gdx
    /jdk/jdk-17.0.8+7 (copy of jdk 17 here)
/badass-runtime-plugin

```

1. The runtime plugin (included via [composite builds](https://docs.gradle.org/current/userguide/composite_builds.html#included_build_declaring_substitutions) in the project) requires Java 11 to be built (so the entire gradle project is running using java 11 by setting the gradle jvm in intellij)
2. The jdk [specified](https://github.com/fourlastor-alexandria/construo-gdx/pull/1/files#diff-6154f3e125f7b41e9f0ded9d8c48105a8d2080c9039acdb54a7743882b05f19cR82) to the runtime plugin is 17

Checking out the `master` branch of the runtime plugin fails the build (as it tries to use the gradle jdk - 11, to run jpackage, which doesn't exist), while the fix branch succeeds