### PR TITLE
Fix build JDK version check to match documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ plugins {
     id "org.ajoberstar.git-publish" version "4.1.1"
 }
 
-if(JavaVersion.current() != JavaVersion.VERSION_11) {
-    throw new GradleException("Please use Java 11 to execute this Gradle build")
+if(!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
+    throw new GradleException("Please use Java 11 or above to execute this Gradle build")
 }
 
 project.version.with {


### PR DESCRIPTION
The current documentation at https://badass-runtime-plugin.beryx.org/releases/1.13.0/ states:

> The plugin requires Java 11 and Gradle 7.0 or newer. [...]

Building with JDK 17 actually works.