### PR TITLE
Fix cast exception on invalid class entries

### DIFF
--- a/src/main/groovy/org/beryx/runtime/util/PackageUseScanner.groovy
+++ b/src/main/groovy/org/beryx/runtime/util/PackageUseScanner.groovy
@@ -212,6 +212,7 @@ class PackageUseScanner extends ClassVisitor {
                 } catch (Exception e) {
                     LOGGER.info("Failed to scan $path", e)
                     invalidEntries << ("${basePath}/${path}" as String)
+                    return
                 }
             }
         } as Closure)


### PR DESCRIPTION
If the class reader cannot parse an entry in the PackageUseScanner, it will write path in the list invalidEntries. It uses the leftshift operator on the list which returns the list and since it is the last command in the action, the return value of the whole action will be the list. This produces a "GroovyCastException" in Util.scanJar() because action is expected to be of type Closure<Void> and the ArrayList cannot be casted to Void. This exception terminates the whole JRE task.
By adding a return statement after the leftshift on the list, the action won't return anything and the exception isn't triggered.

This error can reproduce by having ch.qos.logback:logback-core:1.5.3 as dependency and using a JDK version<21 because is a multi-release jar and contains classes which are compiled for JDK version 21. The class reader won't be able to parse those.
Here is the StackTrace:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':jre'.
Caused by: org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object '[/META-INF/versions/21/ch/qos/logback/core/util/ExecutorServiceUtil$1.class]' with class 'java.util.ArrayList' to class 'java.lang.Void' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: java.lang.Void(String)
	at org.beryx.runtime.util.Util$_scanJar_closure2.doCall$original(Util.groovy:75)
	at org.beryx.runtime.util.Util$_scanJar_closure2.doCall(Util.groovy)
	at jdk.internal.reflect.GeneratedMethodAccessor741.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.beryx.runtime.util.Util.scanJar(Util.groovy:75)
	at org.beryx.runtime.util.Util.scan(Util.groovy:59)
	at org.beryx.runtime.util.PackageUseScanner.scan(PackageUseScanner.groovy:206)
	at org.beryx.runtime.util.SuggestedModulesBuilder.getModulesRequiredBy(SuggestedModulesBuilder.groovy:51)
	at org.beryx.runtime.util.SuggestedModulesBuilder.getProjectModules(SuggestedModulesBuilder.groovy:40)
	at org.beryx.runtime.impl.JreTaskImpl.getModules(JreTaskImpl.groovy:81)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.beryx.runtime.impl.JreTaskImpl.createJre(JreTaskImpl.groovy:57)
	at org.beryx.runtime.impl.JreTaskImpl$_execute_closure1.doCall$original(JreTaskImpl.groovy:39)
	at org.beryx.runtime.impl.JreTaskImpl$_execute_closure1.doCall(JreTaskImpl.groovy)
	at org.beryx.runtime.impl.JreTaskImpl$_execute_closure1.call(JreTaskImpl.groovy)
	at org.beryx.runtime.impl.JreTaskImpl.execute(JreTaskImpl.groovy:37)
	at org.beryx.runtime.JreTask.runtimeTaskAction(JreTask.groovy:83)
	Suppressed: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: java.lang.Void(ArrayList)
		at groovy.lang.MetaClassImpl.invokeConstructor(MetaClassImpl.java:1835)
		at groovy.lang.MetaClassImpl.invokeConstructor(MetaClassImpl.java:1605)
		at org.codehaus.groovy.runtime.InvokerHelper.invokeConstructorOf(InvokerHelper.java:1067)
		at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnSAM(DefaultTypeTransformation.java:378)
		at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnNumber(DefaultTypeTransformation.java:315)
		at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.castToType(DefaultTypeTransformation.java:243)
		at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.castToType(ScriptBytecodeAdapter.java:615)
		at org.beryx.runtime.util.Util$_scanJar_closure2.doCall$original(Util.groovy:75)
		at org.beryx.runtime.util.Util$_scanJar_closure2.doCall(Util.groovy)
		at jdk.internal.reflect.GeneratedMethodAccessor741.invoke(Unknown Source)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:568)
		at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:107)
		at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
		at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:274)
		at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1035)
		at groovy.lang.Closure.call(Closure.java:412)
		at groovy.lang.Closure.call(Closure.java:428)
		at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2357)
		at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2185)
		at org.beryx.runtime.util.Util.scanJar(Util.groovy:75)
		at org.beryx.runtime.util.Util.scan(Util.groovy:59)
		at org.beryx.runtime.util.PackageUseScanner.scan(PackageUseScanner.groovy:206)
		at org.beryx.runtime.util.SuggestedModulesBuilder.getModulesRequiredBy(SuggestedModulesBuilder.groovy:51)
		at org.beryx.runtime.util.SuggestedModulesBuilder.getProjectModules(SuggestedModulesBuilder.groovy:40)
		at org.beryx.runtime.impl.JreTaskImpl.getModules(JreTaskImpl.groovy:81)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:568)
		at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:107)
		at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
		at org.codehaus.groovy.runtime.metaclass.MethodMetaProperty$GetBeanMethodMetaProperty.getProperty(MethodMetaProperty.java:76)
		at org.codehaus.groovy.runtime.callsite.GetEffectivePogoPropertySite.getProperty(GetEffectivePogoPropertySite.java:85)
		at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGroovyObjectGetProperty(AbstractCallSite.java:341)
		at org.beryx.runtime.impl.JreTaskImpl.createJre(JreTaskImpl.groovy:57)
		at org.beryx.runtime.impl.JreTaskImpl$_execute_closure1.doCall$original(JreTaskImpl.groovy:39)
		at org.beryx.runtime.impl.JreTaskImpl$_execute_closure1.doCall(JreTaskImpl.groovy)
		at org.beryx.runtime.impl.JreTaskImpl$_execute_closure1.call(JreTaskImpl.groovy)
		at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2357)
		at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2342)
		at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2371)
		at org.beryx.runtime.impl.JreTaskImpl.execute(JreTaskImpl.groovy:37)
		at org.beryx.runtime.JreTask.runtimeTaskAction(JreTask.groovy:83)
