### PR TITLE
upgrade asm version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ ext.badassRuntimePluginTag = Boolean.valueOf(badassRuntimePluginReleaseBuild) ? 
 group = 'org.beryx'
 version = badassRuntimePluginVersion
 
-ext.asmVersion = '9.4'
+ext.asmVersion = '9.7'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
There was an error when compile my project on java 21 with this plugin:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':jre'.
> Cannot cast object '[/ru/sgk/chatnotesdesktop/Launcher.class]' with class 'java.util.ArrayList' to class 'java.lang.Void' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: java.lang.Void(String)
```

The cause of error is that `ClassReader`, used in `PackageUseScanner:210` throws an Exception:
```
java.lang.IllegalArgumentException: Unsupported class file major version 65
```

Error gone with upgrade asm to newer version.