### PR TITLE
Fix compatibility with Gradle 9

### DIFF
--- a/src/main/groovy/org/beryx/runtime/BaseTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/BaseTask.groovy
@@ -19,7 +19,10 @@ import groovy.transform.CompileStatic
 import org.beryx.runtime.data.RuntimePluginExtension
 import org.beryx.runtime.util.Util
 import org.gradle.api.DefaultTask
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Internal
+
+import javax.inject.Inject
 
 import static org.beryx.runtime.util.Util.EXEC_EXTENSION
 
@@ -31,6 +34,11 @@ class BaseTask extends DefaultTask {
     BaseTask() {
         this.extension = (RuntimePluginExtension)project.extensions.getByName(RuntimePlugin.EXTENSION_NAME)
         group = 'build'
+    }
+
+    @Inject
+    protected ObjectFactory getObjectFactory() {
+        throw new UnsupportedOperationException("Gradle overrides this method when creating the task")
     }
 
     @Internal

--- a/src/main/groovy/org/beryx/runtime/JPackageImageTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/JPackageImageTask.groovy
@@ -72,7 +72,7 @@ class JPackageImageTask extends BaseTask {
         def jreTask = (JreTask) project.tasks.getByName(RuntimePlugin.TASK_NAME_JRE)
         taskData.configureRuntimeImageDir(jreTask)
 
-        def taskImpl = new JPackageImageTaskImpl(project, taskData)
+        def taskImpl = objectFactory.newInstance(JPackageImageTaskImpl, project, taskData)
         taskImpl.execute()
     }
 }

--- a/src/main/groovy/org/beryx/runtime/JPackageTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/JPackageTask.groovy
@@ -46,7 +46,7 @@ class JPackageTask extends BaseTask {
         taskData.javaHome = javaHomeOrDefault
         taskData.configureAppImageDir()
 
-        def taskImpl = new JPackageTaskImpl(project, taskData)
+        def taskImpl = objectFactory.newInstance(JPackageTaskImpl, project, taskData)
         taskImpl.execute()
     }
 }

--- a/src/main/groovy/org/beryx/runtime/JreTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/JreTask.groovy
@@ -79,7 +79,7 @@ class JreTask extends BaseTask {
         taskData.javaHome = javaHome
         taskData.targetPlatforms = targetPlatforms.get()
 
-        def taskImpl = new JreTaskImpl(project, taskData)
+        def taskImpl = objectFactory.newInstance(JreTaskImpl, project, taskData)
         taskImpl.execute()
     }
 }

--- a/src/main/groovy/org/beryx/runtime/RuntimeZipTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/RuntimeZipTask.groovy
@@ -55,7 +55,7 @@ class RuntimeZipTask extends BaseTask {
         taskData.targetPlatforms = targetPlatforms.get()
         taskData.imageDir = imageDir.asFile
         taskData.imageZip = imageZip.asFile
-        def taskImpl = new RuntimeZipTaskImpl(project, taskData)
+        def taskImpl = objectFactory.newInstance(RuntimeZipTaskImpl, project, taskData)
         taskImpl.execute()
     }
 }

--- a/src/main/groovy/org/beryx/runtime/SuggestModulesTask.groovy
+++ b/src/main/groovy/org/beryx/runtime/SuggestModulesTask.groovy
@@ -38,7 +38,7 @@ class SuggestModulesTask extends BaseTask {
     void suggestMergedModuleInfoAction() {
         def taskData = new SuggestModulesData()
         taskData.javaHome = javaHome
-        def taskImpl = new SuggestModulesTaskImpl(project, taskData)
+        def taskImpl = objectFactory.newInstance(SuggestModulesTaskImpl, project, taskData)
         taskImpl.execute()
     }
 }

--- a/src/main/groovy/org/beryx/runtime/impl/BaseTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/BaseTaskImpl.groovy
@@ -18,16 +18,31 @@ package org.beryx.runtime.impl
 
 import groovy.transform.CompileStatic
 import org.gradle.api.Project
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecResult
+import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
 
 @CompileStatic
-class BaseTaskImpl<DATA> {
+abstract class BaseTaskImpl<DATA> {
     static String SEP = File.pathSeparatorChar
 
     final Project project
     final DATA td
 
+    @Inject
+    protected abstract ExecOperations getExecOperations() // Gradle provides implementation
+
     BaseTaskImpl(Project project, DATA td) {
         this.project = project
         this.td = td
+    }
+
+    protected ExecResult exec(@DelegatesTo(ExecSpec) Closure<?> spec) {
+        return execOperations.exec {
+            spec.delegate = it
+            spec()
+        }
     }
 }

--- a/src/main/groovy/org/beryx/runtime/impl/JPackageImageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/JPackageImageTaskImpl.groovy
@@ -27,10 +27,13 @@ import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 
+import javax.inject.Inject
+
 @CompileStatic
-class JPackageImageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
+abstract class JPackageImageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
     private static final Logger LOGGER = Logging.getLogger(JPackageImageTaskImpl.class)
 
+    @Inject
     JPackageImageTaskImpl(Project project, JPackageTaskData taskData) {
         super(project, taskData)
         LOGGER.debug("taskData: $taskData")
@@ -38,7 +41,7 @@ class JPackageImageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
 
     @CompileDynamic
     void execute() {
-        def result = project.exec {
+        def result = exec {
             ignoreExitValue = true
             standardOutput = new ByteArrayOutputStream()
 

--- a/src/main/groovy/org/beryx/runtime/impl/JPackageTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/JPackageTaskImpl.groovy
@@ -28,10 +28,13 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.internal.os.OperatingSystem
 
+import javax.inject.Inject
+
 @CompileStatic
-class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
+abstract class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
     private static final Logger LOGGER = Logging.getLogger(JPackageTaskImpl.class);
 
+    @Inject
     JPackageTaskImpl(Project project, JPackageTaskData taskData) {
         super(project, taskData)
         LOGGER.debug("taskData: $taskData")
@@ -56,7 +59,7 @@ class JPackageTaskImpl extends BaseTaskImpl<JPackageTaskData> {
                 def subdirs = installerOutDir.listFiles({ f -> f.directory } as FileFilter)
                 if(subdirs) project.delete(subdirs)
             }
-            def result = project.exec {
+            def result = exec {
                 ignoreExitValue = true
                 standardOutput = new ByteArrayOutputStream()
                 project.ext.jpackageInstallerOutput = {

--- a/src/main/groovy/org/beryx/runtime/impl/JreTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/JreTaskImpl.groovy
@@ -23,9 +23,12 @@ import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 
-class JreTaskImpl extends BaseTaskImpl<JreTaskData> {
+import javax.inject.Inject
+
+abstract class JreTaskImpl extends BaseTaskImpl<JreTaskData> {
     private static final Logger LOGGER = Logging.getLogger(JreTaskImpl)
 
+    @Inject
     JreTaskImpl(Project project, JreTaskData taskData) {
         super(project, taskData)
         LOGGER.info("taskData: $taskData")
@@ -57,7 +60,7 @@ class JreTaskImpl extends BaseTaskImpl<JreTaskData> {
                        '--add-modules', modules.join(','),
                        '--output', jreDir]
         LOGGER.info("Executing: $cmd")
-        def result = project.exec {
+        def result = exec {
             ignoreExitValue = true
             standardOutput = new ByteArrayOutputStream()
             project.ext.jlinkOutput = {

--- a/src/main/groovy/org/beryx/runtime/impl/RuntimeTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/RuntimeTaskImpl.groovy
@@ -21,9 +21,12 @@ import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 
-class RuntimeTaskImpl extends BaseTaskImpl<RuntimeTaskData> {
+import javax.inject.Inject
+
+abstract class RuntimeTaskImpl extends BaseTaskImpl<RuntimeTaskData> {
     private static final Logger LOGGER = Logging.getLogger(RuntimeTaskImpl)
 
+    @Inject
     RuntimeTaskImpl(Project project, RuntimeTaskData taskData) {
         super(project, taskData)
         LOGGER.info("taskData: $taskData")

--- a/src/main/groovy/org/beryx/runtime/impl/RuntimeZipTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/RuntimeZipTaskImpl.groovy
@@ -20,9 +20,12 @@ import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 
-class RuntimeZipTaskImpl extends BaseTaskImpl<RuntimeZipTaskData> {
+import javax.inject.Inject
+
+abstract class RuntimeZipTaskImpl extends BaseTaskImpl<RuntimeZipTaskData> {
     private static final Logger LOGGER = Logging.getLogger(RuntimeZipTaskImpl)
 
+    @Inject
     RuntimeZipTaskImpl(Project project, RuntimeZipTaskData taskData) {
         super(project, taskData)
         LOGGER.info("taskData: $taskData")

--- a/src/main/groovy/org/beryx/runtime/impl/SuggestModulesTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/SuggestModulesTaskImpl.groovy
@@ -20,10 +20,14 @@ import org.beryx.runtime.util.SuggestedModulesBuilder
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.process.ExecOperations
 
-class SuggestModulesTaskImpl extends BaseTaskImpl<SuggestModulesData> {
+import javax.inject.Inject
+
+abstract class SuggestModulesTaskImpl extends BaseTaskImpl<SuggestModulesData> {
     private static final Logger LOGGER = Logging.getLogger(SuggestModulesTaskImpl)
 
+    @Inject
     SuggestModulesTaskImpl(Project project, SuggestModulesData taskData) {
         super(project, taskData)
         LOGGER.info("taskData: $taskData")


### PR DESCRIPTION
`Project.exec` is no longer available in Gradle 9. `ExecOperations` is the drop-in replacement available since 6.0.

Methods on tasks are protected with dummy implementations, which isn't up-to-date with Gradle guidelines to prevent breaking users who extend these tasks. `BaseTaskImpl` and its descendants follow Gradle guidelines for inject consumers.

There is no `ExecOperations.exec(Closure)` visible to IDE, so a helper `exec` method is defined to avoid adding `it`. qualifier everywhere.

Based on https://github.com/beryx/badass-runtime-plugin/pull/156 with the imports in a more consistent order.

Fixes https://github.com/beryx/badass-runtime-plugin/issues/155.