### PR TITLE
Fixes #162

### DIFF
--- a/src/main/groovy/org/beryx/runtime/impl/RuntimeZipTaskImpl.groovy
+++ b/src/main/groovy/org/beryx/runtime/impl/RuntimeZipTaskImpl.groovy
@@ -48,7 +48,7 @@ abstract class RuntimeZipTaskImpl extends BaseTaskImpl<RuntimeZipTaskData> {
         }
     }
 
-    private void createZip(File imageDir, File zipFile) {
+    protected void createZip(File imageDir, File zipFile) {
         def parentPath = imageDir.parentFile.toPath()
         project.ant.zip(destfile: zipFile, duplicate: 'fail') {
             imageDir.eachFileRecurse { f ->


### PR DESCRIPTION
AFAIU the problem is that Gradle creates a subclass of the task implementation (Decorated class) and when Groovy tries to resolve the private method on the subclass it is unable to find it, because it is private to the superclass.